### PR TITLE
不要なpre-commitの設定ファイルを削除

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,0 @@
-repos:
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.16.1
-    hooks:
-      - id: gitleaks


### PR DESCRIPTION
リポジトリごとにgitleaks設定を追加するのではなく、開発者環境でグローバルにgitleaksを有効化する方針としたので、pre-commitの設定ファイルが不要となった。そのため削除する。